### PR TITLE
#44 add Ledger Nano S support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "lupoex-client",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -7342,6 +7342,31 @@
                 "invert-kv": "1.0.0"
             }
         },
+        "ledgerco": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/ledgerco/-/ledgerco-1.1.3.tgz",
+            "integrity": "sha1-Qs2xLm5V5VEq0oAZlK4wQX+qOuQ=",
+            "requires": {
+                "async": "2.1.4",
+                "node-hid": "0.5.4",
+                "q": "1.4.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+                    "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+                    "requires": {
+                        "lodash": "4.17.4"
+                    }
+                },
+                "q": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                    "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
+                }
+            }
+        },
         "leven": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -7852,8 +7877,7 @@
         "nan": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-            "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-            "dev": true
+            "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -7940,6 +7964,771 @@
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                     "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                     "dev": true
+                }
+            }
+        },
+        "node-hid": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-0.5.4.tgz",
+            "integrity": "sha1-pyRt/AjVJ3QUf6JkNU1dpuq0AlM=",
+            "requires": {
+                "nan": "2.8.0",
+                "node-pre-gyp": "0.6.31"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.0.9",
+                    "bundled": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "bundled": true
+                },
+                "aproba": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.2"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true
+                },
+                "aws4": {
+                    "version": "1.5.0",
+                    "bundled": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.6",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "caseless": {
+                    "version": "0.11.0",
+                    "bundled": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "commander": {
+                    "version": "2.9.0",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "ms": "0.7.1"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.4.1",
+                    "bundled": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.0"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "bundled": true
+                },
+                "extend": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true
+                },
+                "form-data": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.14"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "fstream": {
+                    "version": "1.0.10",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.5.4"
+                    }
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "fstream": "1.0.10",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.3"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "1.0.4",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.0",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "0.2.0",
+                        "wide-align": "1.1.0"
+                    }
+                },
+                "generate-function": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "generate-object-property": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "is-property": "1.0.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.6",
+                    "bundled": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.3",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true
+                },
+                "graceful-readlink": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "har-validator": {
+                    "version": "2.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "commander": "2.9.0",
+                        "is-my-json-valid": "2.15.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.3.1",
+                        "sshpk": "1.10.2"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-my-json-valid": {
+                    "version": "2.15.0",
+                    "bundled": true,
+                    "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "4.0.1",
+                        "xtend": "4.0.1"
+                    }
+                },
+                "is-property": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.0"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "jsonpointer": {
+                    "version": "4.0.1",
+                    "bundled": true
+                },
+                "jsprim": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "requires": {
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    }
+                },
+                "mime-db": {
+                    "version": "1.26.0",
+                    "bundled": true
+                },
+                "mime-types": {
+                    "version": "2.1.14",
+                    "bundled": true,
+                    "requires": {
+                        "mime-db": "1.26.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "1.1.6"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "0.7.1",
+                    "bundled": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.31",
+                    "bundled": true,
+                    "requires": {
+                        "mkdirp": "0.5.1",
+                        "nopt": "3.0.6",
+                        "npmlog": "4.0.2",
+                        "rc": "1.1.6",
+                        "request": "2.79.0",
+                        "rimraf": "2.5.4",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.3.0"
+                    }
+                },
+                "nopt": {
+                    "version": "3.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "abbrev": "1.0.9"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.2",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.2",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true
+                },
+                "object-assign": {
+                    "version": "4.1.0",
+                    "bundled": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "pinkie": {
+                    "version": "2.0.4",
+                    "bundled": true
+                },
+                "pinkie-promise": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "pinkie": "2.0.4"
+                    }
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true
+                },
+                "qs": {
+                    "version": "6.3.0",
+                    "bundled": true
+                },
+                "rc": {
+                    "version": "1.1.6",
+                    "bundled": true,
+                    "requires": {
+                        "deep-extend": "0.4.1",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "1.0.4"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.2",
+                    "bundled": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.79.0",
+                    "bundled": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.5.0",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.0",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.2",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.14",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.3.0",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.4.3",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.5.4",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "7.1.1"
+                    }
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.10.2",
+                    "bundled": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.0",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.6",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.0",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "bundled": true
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "supports-color": {
+                    "version": "0.2.0",
+                    "bundled": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.10",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-pack": {
+                    "version": "3.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "debug": "2.2.0",
+                        "fstream": "1.0.10",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.3.3",
+                        "readable-stream": "2.1.5",
+                        "rimraf": "2.5.4",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    },
+                    "dependencies": {
+                        "once": {
+                            "version": "1.3.3",
+                            "bundled": true,
+                            "requires": {
+                                "wrappy": "1.0.2"
+                            }
+                        },
+                        "readable-stream": {
+                            "version": "2.1.5",
+                            "bundled": true,
+                            "requires": {
+                                "buffer-shims": "1.0.0",
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.7",
+                                "string_decoder": "0.10.31",
+                                "util-deprecate": "1.0.2"
+                            }
+                        }
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.4.3",
+                    "bundled": true
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "xtend": {
+                    "version": "4.0.1",
+                    "bundled": true
                 }
             }
         },
@@ -12512,6 +13301,30 @@
                 "tweetnacl": "0.14.5"
             }
         },
+        "stellar-ledger-api": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/stellar-ledger-api/-/stellar-ledger-api-1.1.3.tgz",
+            "integrity": "sha512-PQi0akei+IKnxos3Iuyzw7Etaz1HtxmwElp4au9hYvjBxRhX+NbSSOU6VqVzK/8luOkLOfLmImS4VIqiGfe/wA==",
+            "requires": {
+                "base32.js": "0.1.0",
+                "crc": "3.5.0",
+                "ledgerco": "1.1.3",
+                "q": "1.4.1",
+                "tweetnacl": "1.0.0"
+            },
+            "dependencies": {
+                "q": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                    "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
+                },
+                "tweetnacl": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+                    "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+                }
+            }
+        },
         "stellar-sdk": {
             "version": "0.7.3",
             "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-0.7.3.tgz",
@@ -12572,14 +13385,6 @@
             "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
             "dev": true
         },
-        "string_decoder": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-            "requires": {
-                "safe-buffer": "5.1.1"
-            }
-        },
         "string-length": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -12607,6 +13412,14 @@
             "requires": {
                 "is-fullwidth-code-point": "2.0.0",
                 "strip-ansi": "4.0.0"
+            }
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "requires": {
+                "safe-buffer": "5.1.1"
             }
         },
         "stringstream": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
         "sails.io.js": "1.1.12",
         "select2": "4.0.3",
         "socket.io-client": "2.0.3",
+        "stellar-ledger-api": "1.1.3",
         "stellar-sdk": "0.7.3",
         "techan": "0.8.0",
         "tooltipster": "4.2.2"

--- a/src/app/resources/auth/login/login.html
+++ b/src/app/resources/auth/login/login.html
@@ -18,6 +18,14 @@
                         </label>
                         <input type="password" value.bind="secretKey">
                     </div>
+                    <br/>
+                    <h5 class="center">Or</h5>
+                    <div>
+                        <label>Connect Ledger Nano S
+                            <i class="primary-text fa fa-question-circle-o" md-tooltip="text: Available on Chrome and Opera. Install the Stellar app from Ledger and enable browser support in the app settings."></i>
+                        </label>
+                        <bip32-path-input if.bind="ledgerConnected" bip32-path.bind="bip32Path" title="BIP32 path"></bip32-path-input>
+                    </div>
                     <div class="cols center-align form-field">
                         <button md-waves type="submit" class="btn primary">
                             <i class="fa fa-check"></i>&nbsp;Login

--- a/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-transaction-modal.html
+++ b/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-transaction-modal.html
@@ -2,6 +2,7 @@
     <require from="./choose-signing-method/choose-signing-method"></require>
     <require from="./sign-with-provided-secret/sign-with-provided-secret"></require>
     <require from="./sign-manually/sign-manually"></require>
+    <require from="./sign-with-ledger/sign-with-ledger"></require>
     <div class="sign-transaction-modal">
         <choose-signing-method show.bind="!method" methods.bind="methods" method-chosen.call="methodChosen(method)"></choose-signing-method>
 
@@ -10,5 +11,8 @@
 
         <sign-manually show.bind="method === 'signManually'" back.call="methodChosen()"
                        transaction.bind="transaction" transaction-signed.call="transactionSigned(signedTransaction)"></sign-manually>
+        <sign-with-ledger show.bind="method === 'signWithLedger'" back.call="methodChosen()"
+                          transaction.bind="transaction" transaction-signed.call="transactionSigned(signedTransaction)"></sign-with-ledger>
+
     </div>
 </template>

--- a/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-transaction-modal.js
+++ b/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-transaction-modal.js
@@ -9,6 +9,10 @@ export class SignTransactionModal {
             description: 'We will provide you with the raw transaction and an input for the signed transaction. ' +
             'In order to submit your transaction to the network, you must manually sign the transaction with your account\'s secret key. ' +
             'Once you have provided us with the valid signed transaction, we will submit it to the network.'
+        },
+        signWithLedger: {
+            title: 'Sign with Ledger Nano S',
+            description: 'Transaction will be sent to device for signing'
         }
     };
 

--- a/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-with-ledger/sign-with-ledger.html
+++ b/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-with-ledger/sign-with-ledger.html
@@ -1,0 +1,25 @@
+<template>
+    <div class="sign-with-ledger">
+        <alert-card type="info" title="Sign Your Transaction With Ledger">
+            <div>
+                Make sure your Ledger is Connected and the Stellar app open.
+                Click the 'Sign' button and you will be prompted on your device.
+            </div>
+        </alert-card>
+        <alert-card show.bind="errorMessage" title="Error with your Ledger" type="error">
+            <div>${errorMessage}</div>
+        </alert-card>
+        <form novalidate focus-input submit.trigger="sign()">
+            <div class="row">
+                <div class="cols center-align form-field">
+                    <button md-waves type="button" class="btn gray" click.trigger="back()">
+                        <i class="fa fa-arrow-left"></i>&nbsp;Back
+                    </button>
+                    <button md-waves type="submit" class="btn primary">
+                        <i class="fa fa-lock"></i>&nbsp;Sign
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</template>

--- a/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-with-ledger/sign-with-ledger.js
+++ b/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-with-ledger/sign-with-ledger.js
@@ -1,0 +1,45 @@
+import {bindable, inject} from 'aurelia-framework';
+import * as StellarSdk from 'stellar-sdk';
+import {ValidationManager} from 'global-resources';
+import {Store} from 'au-redux';
+import StellarLedger from 'stellar-ledger-api';
+
+@inject(Store)
+export class SignWithLedgerCustomElement {
+
+    @bindable() transactionSigned;
+    @bindable() transaction;
+    @bindable() back;
+
+    constructor(store) {
+        this.store = store;
+    }
+
+    activate(params) {
+        this.modalVM = params.modalVM;
+    }
+
+    async sign() {
+        const account = this.store.getState().myAccount;
+
+        if (!account) {
+            this.errorMessage = 'Hey, you aren\'t logged in. You can\'t create a transaction without being logged in first silly. Please login and try again.';
+            return;
+        }
+
+        const keypair = StellarSdk.Keypair.fromPublicKey(account.accountId);
+
+        const bip32Path = "44'/148'/0'"; // TODO: get from store
+        await new StellarLedger.Api(new StellarLedger.comm(60)).signTx_async(bip32Path, this.transaction).then((result) => {
+            this.transaction.signatures.push(new StellarSdk.xdr.DecoratedSignature({hint: keypair.signatureHint(), signature: result.signature}));
+
+            this.transactionSigned({
+                signedTransaction: this.transaction
+            });
+        }).catch((err) => {
+            console.log(err);
+            this.errorMessage = err;
+        });
+
+    }
+}

--- a/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-with-ledger/sign-with-ledger.scss
+++ b/src/app/resources/crud/stellar/transaction-service/sign-transaction-modal/sign-with-ledger/sign-with-ledger.scss
@@ -1,0 +1,15 @@
+.sign-with-ledger {
+    .copy-label i {
+        cursor: pointer;
+    }
+
+    .copy-transaction {
+        font-size: 12px;
+        color: $primary;
+        word-break: break-all;
+    }
+
+    .materialize-textarea {
+        font-size: 12px;
+    }
+}

--- a/src/app/resources/dom-controls/bip32-path-input/bip32-path-input.html
+++ b/src/app/resources/dom-controls/bip32-path-input/bip32-path-input.html
@@ -1,0 +1,11 @@
+<template>
+    <div class="bip32-path-input">
+        <label class="accent-text">-- enter BIP32 path or leave at default --</label>
+        <input value.bind="inputValue" placeholder="BIP32 path: 44'/148'/n'"><br>
+        <div if.bind="inputValue">
+            <div>
+                <span if.bind="!isValidBip32Path" class="error-text"><i class="fa fa-exclamation-circle"></i>&nbsp;Invalid BIP32 path</span>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/app/resources/dom-controls/bip32-path-input/bip32-path-input.js
+++ b/src/app/resources/dom-controls/bip32-path-input/bip32-path-input.js
@@ -1,0 +1,39 @@
+/**
+ * Created by istrauss on 6/22/2017.
+ */
+
+import {bindable, bindingMode} from 'aurelia-framework';
+
+export class Bip32PathInputCustomElement {
+
+    @bindable({
+        defaultBindingMode: bindingMode.twoWay
+    })
+    bip32Path;
+
+    isValidBip32Path = true;
+
+    get inputValue() {
+        return this._inputValue || this.bip32Path;
+    }
+    set inputValue(newValue) {
+        this._inputValue = newValue;
+        this.checkBip32Path(newValue);
+        if (this.isValidBip32Path) {
+            this.bip32Path = newValue;
+        }
+    }
+    checkBip32Path(path) {
+        this.isValidBip32Path = true;
+        if (!path.startsWith("44'/148'")) {
+            this.isValidBip32Path = false;
+            return;
+        }
+        path.split('/').forEach((element) => {
+            if (!element.toString().endsWith('\'')) {
+                this.isValidBip32Path = false;
+            }
+        });
+    }
+
+}

--- a/src/app/resources/index.js
+++ b/src/app/resources/index.js
@@ -15,6 +15,7 @@ export function configure(config) {
         PLATFORM.moduleName('./value-converters/number'),
         PLATFORM.moduleName('./value-converters/order'),
         PLATFORM.moduleName('./dom-controls/stellar-address-input/stellar-address-input'),
+        PLATFORM.moduleName('./dom-controls/bip32-path-input/bip32-path-input'),
         PLATFORM.moduleName('./display-elements/asset-card/asset-card'),
         PLATFORM.moduleName('./display-elements/asset-pair-cards/asset-pair-cards'),
         PLATFORM.moduleName('./crud/stellar/asset-selection-sidebar/asset-selection-sidebar'),


### PR DESCRIPTION
Proposal how Ledger Nano S support could be implemented. On the login page another method of logging in is added. When the user connects the Ledger and opens the Stellar app an extra field to enter a custom bip32 path is shown. The login method detects whether a Ledger is connected and will get the public key automatically from the device when the user clicks Log In button. The PR also adds a signing method to the signing dialog to sign with the Ledger device. One thing that is missing is that the bip32 path should be saved to persistent storage on login, to be used later when signing transactions.